### PR TITLE
Fix log crash when it try to log a CURLFile as text

### DIFF
--- a/TelegramErrorLogger.php
+++ b/TelegramErrorLogger.php
@@ -85,7 +85,7 @@ class TelegramErrorLogger
         }
         foreach ($array as $key => $value) {
             if($value instanceof CURLFile){
-                $text .= $ref.'.'.$key.'= CURLFile'.PHP_EOL;
+                $text .= $ref.'.'.$key.'= File'.PHP_EOL;
             }else if (is_array($value)) {
                 if ($title != null) {
                     $key = $title.'.'.$key;

--- a/TelegramErrorLogger.php
+++ b/TelegramErrorLogger.php
@@ -84,7 +84,9 @@ class TelegramErrorLogger
             $text .= "\n";
         }
         foreach ($array as $key => $value) {
-            if (is_array($value)) {
+            if($value instanceof CURLFile){
+                $text .= $ref.'.'.$key.'= CURLFile'.PHP_EOL;
+            }else if (is_array($value)) {
                 if ($title != null) {
                     $key = $title.'.'.$key;
                 }


### PR DESCRIPTION
When send attachment function are used, the logger try to log the message.  
In this scenario it will try to log a file as a general text, and so it will throw an exception.  
Now we check instanceof CURLFile and then print only "File" string instead of CURLFile object.