### PR TITLE
Fix: UserID when update is inline_query

### DIFF
--- a/Telegram.php
+++ b/Telegram.php
@@ -1082,6 +1082,9 @@ class Telegram
         if ($type == self::EDITED_MESSAGE) {
             return @$this->data['edited_message']['from']['id'];
         }
+        if ($type == self::INLINE_QUERY) {
+            return @$this->data['inline_query']['from']['id'];
+        }
 
         return $this->data['message']['from']['id'];
     }


### PR DESCRIPTION
if the update is inline_query, the `$bot->UserID` has some problems with it.
this pull request will fix it.